### PR TITLE
Introduce job interval variable

### DIFF
--- a/fjsp/ProblemData.py
+++ b/fjsp/ProblemData.py
@@ -128,12 +128,6 @@ class ProblemData:
             for operation in ops:
                 self._op2machines[operation].append(machine)
 
-        # TODO Remove op2job with https://github.com/leonlan/PyJobShop/issues/44
-        self._op2job: list[int] = [0 for _ in range(self.num_operations)]
-        for job, ops in enumerate(self.job2ops):
-            for operation in ops:
-                self._op2job[operation] = job
-
         self._processing_times = processing_times
         self._precedences = precedences
 
@@ -231,18 +225,6 @@ class ProblemData:
             List of eligible machine indices for each operation.
         """
         return self._op2machines
-
-    @property
-    def op2job(self) -> list[int]:
-        """
-        Job index corresponding to each operation.
-
-        Returns
-        -------
-        list[int]
-            Job index corresponding to each operation.
-        """
-        return self._op2job
 
     @property
     def processing_times(self) -> np.ndarray:

--- a/fjsp/cp/default_model.py
+++ b/fjsp/cp/default_model.py
@@ -5,6 +5,7 @@ from fjsp.ProblemData import ProblemData
 from .constraints import (
     alternative_constraints,
     assignment_precedence_constraints,
+    job_operation_constraints,
     machine_accessibility_constraints,
     no_overlap_constraints,
     timing_precedence_constraints,
@@ -12,6 +13,7 @@ from .constraints import (
 from .objectives import makespan
 from .variables import (
     assignment_variables,
+    job_variables,
     operation_variables,
     sequence_variables,
 )
@@ -23,12 +25,14 @@ def default_model(data: ProblemData) -> CpoModel:
     """
     model = CpoModel()
 
+    jobs = job_variables(model, data)
     ops = operation_variables(model, data)
     assign = assignment_variables(model, data)
     sequences = sequence_variables(model, data, assign)
 
     model.add(makespan(model, data, ops))
 
+    model.add(job_operation_constraints(model, data, jobs, ops))
     model.add(timing_precedence_constraints(model, data, ops))
     model.add(
         assignment_precedence_constraints(model, data, assign, sequences)

--- a/fjsp/cp/default_model.py
+++ b/fjsp/cp/default_model.py
@@ -25,20 +25,20 @@ def default_model(data: ProblemData) -> CpoModel:
     """
     model = CpoModel()
 
-    jobs = job_variables(model, data)
-    ops = operation_variables(model, data)
-    assign = assignment_variables(model, data)
-    sequences = sequence_variables(model, data, assign)
+    job_vars = job_variables(model, data)
+    op_vars = operation_variables(model, data)
+    assign_vars = assignment_variables(model, data)
+    seq_vars = sequence_variables(model, data, assign_vars)
 
-    model.add(makespan(model, data, ops))
+    model.add(makespan(model, data, job_vars))
 
-    model.add(job_operation_constraints(model, data, jobs, ops))
-    model.add(timing_precedence_constraints(model, data, ops))
+    model.add(job_operation_constraints(model, data, job_vars, op_vars))
+    model.add(timing_precedence_constraints(model, data, op_vars))
     model.add(
-        assignment_precedence_constraints(model, data, assign, sequences)
+        assignment_precedence_constraints(model, data, assign_vars, seq_vars)
     )
-    model.add(alternative_constraints(model, data, ops, assign))
-    model.add(no_overlap_constraints(model, data, sequences))
-    model.add(machine_accessibility_constraints(model, data, assign))
+    model.add(alternative_constraints(model, data, op_vars, assign_vars))
+    model.add(no_overlap_constraints(model, data, seq_vars))
+    model.add(machine_accessibility_constraints(model, data, assign_vars))
 
     return model

--- a/fjsp/cp/variables.py
+++ b/fjsp/cp/variables.py
@@ -6,6 +6,13 @@ from fjsp.ProblemData import ProblemData
 AssignVars = dict[tuple[int, int], CpoIntervalVar]
 
 
+def job_variables(m: CpoModel, data: ProblemData) -> list[CpoIntervalVar]:
+    """
+    Creates an interval variable for each job in the problem.
+    """
+    return [m.interval_var(name=f"J{job}") for job in range(data.num_jobs)]
+
+
 def operation_variables(
     m: CpoModel, data: ProblemData
 ) -> list[CpoIntervalVar]:
@@ -32,13 +39,6 @@ def assignment_variables(m: CpoModel, data: ProblemData) -> AssignVars:
             m.add(
                 m.size_of(var)
                 >= data.processing_times[op, machine] * m.presence_of(var)
-            )
-
-            # Operation may not start before the job's release date if present.
-            job = data.op2job[op]
-            m.add(
-                m.start_of(var)
-                >= data.jobs[job].release_date * m.presence_of(var)
             )
 
     return variables

--- a/fjsp/plot.py
+++ b/fjsp/plot.py
@@ -18,7 +18,7 @@ def plot(data: ProblemData, solution: Solution, plot_labels: bool = False):
     """
     fig, ax = plt.subplots(1, 1, figsize=(12, 8))
 
-    # Use a gradiant color map to assign a unique color to each job.
+    # Operations belonging to the same job get the same unique color.
     colors = plt.cm.tab20c(np.linspace(0, 1, len(data.jobs)))
 
     for scheduled_op in solution.schedule:
@@ -29,17 +29,13 @@ def plot(data: ProblemData, solution: Solution, plot_labels: bool = False):
             scheduled_op.duration,
         )
 
-        # Plot each scheduled operation as a single horizontal bar (interval).
         job = [job for job, ops in enumerate(data.job2ops) if op in ops][0]
-        color = colors[job]
-        kwargs = {"color": color, "linewidth": 1, "edgecolor": "black"}
+        kwargs = {"color": colors[job], "linewidth": 1, "edgecolor": "black"}
         ax.barh(machine, duration, left=start, **kwargs)
 
         if plot_labels:
-            # Plot the operation name as label in the center of the interval.
-            center = start + duration / 2
             ax.text(
-                center,
+                start + duration / 2,
                 machine,
                 data.operations[op].name,
                 ha="center",

--- a/fjsp/plot.py
+++ b/fjsp/plot.py
@@ -30,7 +30,8 @@ def plot(data: ProblemData, solution: Solution, plot_labels: bool = False):
         )
 
         # Plot each scheduled operation as a single horizontal bar (interval).
-        color = colors[data.op2job[op]]
+        job = [job for job, ops in enumerate(data.job2ops) if op in ops][0]
+        color = colors[job]
         kwargs = {"color": color, "linewidth": 1, "edgecolor": "black"}
         ax.barh(machine, duration, left=start, **kwargs)
 


### PR DESCRIPTION
Closes #44.

Also renames the variables into `<abbreviation>_vars`. This is more explicit, since we are distinguishing between three types of "operations" or "jobs":
- `Operation` class (data)
- `operation` index (in the `ProblemData.idx` list)
- `operation` variable

