### PR TITLE
Store processing times in dict

### DIFF
--- a/fjsp/Model.py
+++ b/fjsp/Model.py
@@ -193,24 +193,6 @@ class Model:
 
         self._job2ops[job_idx].extend(op_idcs)
 
-    def assign_machine_operations(
-        self, machine: Machine, operations: list[Operation]
-    ):
-        """
-        Assigns operations to a machine.
-
-        Parameters
-        ----------
-        machine: Machine
-            The machine to which the operations are added.
-        operations: list[Operation]
-            The operations to add to the machine.
-        """
-        machine_idx = self._id2machine[id(machine)]
-        op_idcs = [self._id2op[id(op)] for op in operations]
-
-        self._machine2ops[machine_idx].extend(op_idcs)
-
     def add_processing_time(
         self, operation: Operation, machine: Machine, duration: int
     ):
@@ -232,6 +214,7 @@ class Model:
         op_idx = self._id2op[id(operation)]
         machine_idx = self._id2machine[id(machine)]
         self._processing_times[op_idx, machine_idx] = duration
+        self._machine2ops[machine_idx].append(op_idx)
 
     def add_timing_precedence(
         self,

--- a/fjsp/Model.py
+++ b/fjsp/Model.py
@@ -65,11 +65,6 @@ class Model:
         job2ops = [self._job2ops[idx] for idx in range(num_jobs)]
         machine2ops = [self._machine2ops[idx] for idx in range(num_machines)]
 
-        # Convert processing times into a 2D array with large value as default.
-        processing_times = np.full((num_ops, num_machines), MAX_VALUE)
-        for (op, machine), duration in self._processing_times.items():
-            processing_times[op, machine] = duration
-
         # Convert access matrix into a 2D array with True as default.
         access_matrix = np.full((num_machines, num_machines), True)
         for (machine1, machine2), is_accessible in self._access_matrix.items():
@@ -86,7 +81,7 @@ class Model:
             self.operations,
             job2ops,
             machine2ops,
-            processing_times,
+            self._processing_times,
             self._timing_precedences,
             self._assignment_precedences,
             access_matrix,

--- a/fjsp/Model.py
+++ b/fjsp/Model.py
@@ -27,7 +27,6 @@ class Model:
         self._machines = []
         self._operations = []
         self._job2ops: dict[int, list[int]] = defaultdict(list)
-        self._machine2ops: dict[int, list[int]] = defaultdict(list)
         self._processing_times: dict[tuple[int, int], int] = {}
         self._timing_precedences: dict[
             tuple[int, int], list[tuple[TimingPrecedence, int]]
@@ -63,7 +62,6 @@ class Model:
         num_machines = len(self.machines)
 
         job2ops = [self._job2ops[idx] for idx in range(num_jobs)]
-        machine2ops = [self._machine2ops[idx] for idx in range(num_machines)]
 
         # Convert access matrix into a 2D array with True as default.
         access_matrix = np.full((num_machines, num_machines), True)
@@ -80,7 +78,6 @@ class Model:
             self.machines,
             self.operations,
             job2ops,
-            machine2ops,
             self._processing_times,
             self._timing_precedences,
             self._assignment_precedences,
@@ -214,7 +211,6 @@ class Model:
         machine_idx = self._id2machine[id(machine)]
         op_idx = self._id2op[id(operation)]
         self._processing_times[machine_idx, op_idx] = duration
-        self._machine2ops[machine_idx].append(op_idx)
 
     def add_timing_precedence(
         self,

--- a/fjsp/Model.py
+++ b/fjsp/Model.py
@@ -194,26 +194,26 @@ class Model:
         self._job2ops[job_idx].extend(op_idcs)
 
     def add_processing_time(
-        self, operation: Operation, machine: Machine, duration: int
+        self, machine: Machine, operation: Operation, duration: int
     ):
         """
-        Adds a processing time for an operation on a machine.
+        Adds a processing time for a machine and operation combination.
 
         Parameters
         ----------
-        operation: Operation
-            An operation.
         machine: Machine
             The machine on which the operation is processed.
+        operation: Operation
+            An operation.
         duration: int
             Processing time of the operation on the machine.
         """
         if duration < 0:
             raise ValueError("Processing time must be non-negative.")
 
-        op_idx = self._id2op[id(operation)]
         machine_idx = self._id2machine[id(machine)]
-        self._processing_times[op_idx, machine_idx] = duration
+        op_idx = self._id2op[id(operation)]
+        self._processing_times[machine_idx, op_idx] = duration
         self._machine2ops[machine_idx].append(op_idx)
 
     def add_timing_precedence(

--- a/fjsp/ProblemData.py
+++ b/fjsp/ProblemData.py
@@ -288,7 +288,7 @@ class ProblemData:
         -------
         dict[tuple[int, int], int]
             Processing times of operations on machines. First index is
-            operation index, second index is machine index.
+            the machine index, second index is the operation index.
         """
         return self._processing_times
 

--- a/fjsp/ProblemData.py
+++ b/fjsp/ProblemData.py
@@ -167,7 +167,7 @@ class ProblemData:
         operations: list[Operation],
         job2ops: list[list[int]],
         machine2ops: list[list[int]],
-        processing_times: np.ndarray,
+        processing_times: dict[tuple[int, int], int],
         timing_precedences: dict[
             tuple[int, int], list[tuple[TimingPrecedence, int]]
         ],
@@ -220,12 +220,8 @@ class ProblemData:
         num_mach = self.num_machines
         num_ops = self.num_operations
 
-        if np.any(self.processing_times < 0):
+        if any(duration < 0 for duration in self.processing_times.values()):
             raise ValueError("Processing times must be non-negative.")
-
-        if self.processing_times.shape != (num_ops, num_mach):
-            msg = "Processing times shape must be (num_ops, num_machines)."
-            raise ValueError(msg)
 
         if np.any(self.setup_times < 0):
             raise ValueError("Setup times must be non-negative.")
@@ -284,15 +280,15 @@ class ProblemData:
         return self._machine2ops
 
     @property
-    def processing_times(self) -> np.ndarray:
+    def processing_times(self) -> dict[tuple[int, int], int]:
         """
         Processing times of operations on machines.
 
         Returns
         -------
-        np.ndarray
-            Processing times of operations on machines indexed by operation
-            and machine indices.
+        dict[tuple[int, int], int]
+            Processing times of operations on machines. First index is
+            operation index, second index is machine index.
         """
         return self._processing_times
 

--- a/fjsp/cp/variables.py
+++ b/fjsp/cp/variables.py
@@ -39,7 +39,7 @@ def assignment_variables(m: CpoModel, data: ProblemData) -> AssignVars:
 
             # The duration of the operation on the machine is at least the
             # processing time; it could be longer due to blocking.
-            duration = data.processing_times[op, machine]
+            duration = data.processing_times[machine, op]
             expr = duration * m.presence_of(var) if is_optional else duration
             m.add(m.size_of(var) >= expr)
 

--- a/tests/examples/test_Model.py
+++ b/tests/examples/test_Model.py
@@ -14,7 +14,6 @@ def test_solve():
     operations = [model.add_operation() for _ in range(3)]
 
     model.assign_job_operations(job, operations)
-    model.assign_machine_operations(machine, operations)
 
     for operation, duration in zip(operations, [1, 2, 3]):
         model.add_processing_time(operation, machine, duration)

--- a/tests/examples/test_Model.py
+++ b/tests/examples/test_Model.py
@@ -16,7 +16,7 @@ def test_solve():
     model.assign_job_operations(job, operations)
 
     for operation, duration in zip(operations, [1, 2, 3]):
-        model.add_processing_time(operation, machine, duration)
+        model.add_processing_time(machine, operation, duration)
 
     result = model.solve()
 

--- a/tests/examples/test_ProblemData.py
+++ b/tests/examples/test_ProblemData.py
@@ -18,7 +18,6 @@ def test_earliest_start():
     operation = model.add_operation(earliest_start=1)
 
     model.assign_job_operations(job, [operation])
-    model.assign_machine_operations(machine, [operation])
     model.add_processing_time(operation, machine, duration=1)
 
     result = model.solve()
@@ -45,7 +44,6 @@ def test_latest_start():
         model.add_processing_time(operation, machine, duration=2)
 
     model.assign_job_operations(job, operations)
-    model.assign_machine_operations(machine, operations)
 
     model.add_setup_time(machine, operations[1], operations[0], 10)
 
@@ -71,7 +69,6 @@ def test_fixed_start():
     operation = model.add_operation(earliest_start=42, latest_start=42)
 
     model.assign_job_operations(job, [operation])
-    model.assign_machine_operations(machine, [operation])
     model.add_processing_time(operation, machine, duration=1)
 
     result = model.solve()
@@ -92,7 +89,6 @@ def test_earliest_end():
     operation = model.add_operation(earliest_end=2)
 
     model.assign_job_operations(job, [operation])
-    model.assign_machine_operations(machine, [operation])
     model.add_processing_time(operation, machine, duration=1)
 
     result = model.solve()
@@ -120,7 +116,6 @@ def test_latest_end():
         model.add_processing_time(operation, machine, duration=2)
 
     model.assign_job_operations(job, operations)
-    model.assign_machine_operations(machine, operations)
 
     model.add_setup_time(machine, operations[1], operations[0], 10)
 
@@ -146,7 +141,6 @@ def test_fixed_end():
     operation = model.add_operation(earliest_end=42, latest_end=42)
 
     model.assign_job_operations(job, [operation])
-    model.assign_machine_operations(machine, [operation])
     model.add_processing_time(operation, machine, duration=1)
 
     result = model.solve()
@@ -193,8 +187,6 @@ def test_timing_precedence(
     model.assign_job_operations(job, operations)
 
     for machine in machines:
-        model.assign_machine_operations(machine, operations)
-
         for operation in operations:
             model.add_processing_time(operation, machine, duration=2)
 
@@ -242,8 +234,6 @@ def test_timing_precedence_with_one_delay(
     model.assign_job_operations(job, operations)
 
     for machine in machines:
-        model.assign_machine_operations(machine, operations)
-
         for operation in operations:
             model.add_processing_time(operation, machine, duration=2)
 
@@ -280,8 +270,6 @@ def test_assignment_precedence(
     model.assign_job_operations(job, operations)
 
     for machine in machines:
-        model.assign_machine_operations(machine, operations)
-
         for operation in operations:
             model.add_processing_time(operation, machine, duration=2)
 

--- a/tests/examples/test_ProblemData.py
+++ b/tests/examples/test_ProblemData.py
@@ -18,7 +18,7 @@ def test_earliest_start():
     operation = model.add_operation(earliest_start=1)
 
     model.assign_job_operations(job, [operation])
-    model.add_processing_time(operation, machine, duration=1)
+    model.add_processing_time(machine, operation, duration=1)
 
     result = model.solve()
 
@@ -41,7 +41,7 @@ def test_latest_start():
     ]
 
     for operation in operations:
-        model.add_processing_time(operation, machine, duration=2)
+        model.add_processing_time(machine, operation, duration=2)
 
     model.assign_job_operations(job, operations)
 
@@ -69,7 +69,7 @@ def test_fixed_start():
     operation = model.add_operation(earliest_start=42, latest_start=42)
 
     model.assign_job_operations(job, [operation])
-    model.add_processing_time(operation, machine, duration=1)
+    model.add_processing_time(machine, operation, duration=1)
 
     result = model.solve()
 
@@ -89,7 +89,7 @@ def test_earliest_end():
     operation = model.add_operation(earliest_end=2)
 
     model.assign_job_operations(job, [operation])
-    model.add_processing_time(operation, machine, duration=1)
+    model.add_processing_time(machine, operation, duration=1)
 
     result = model.solve()
 
@@ -113,7 +113,7 @@ def test_latest_end():
     ]
 
     for operation in operations:
-        model.add_processing_time(operation, machine, duration=2)
+        model.add_processing_time(machine, operation, duration=2)
 
     model.assign_job_operations(job, operations)
 
@@ -141,7 +141,7 @@ def test_fixed_end():
     operation = model.add_operation(earliest_end=42, latest_end=42)
 
     model.assign_job_operations(job, [operation])
-    model.add_processing_time(operation, machine, duration=1)
+    model.add_processing_time(machine, operation, duration=1)
 
     result = model.solve()
 
@@ -188,7 +188,7 @@ def test_timing_precedence(
 
     for machine in machines:
         for operation in operations:
-            model.add_processing_time(operation, machine, duration=2)
+            model.add_processing_time(machine, operation, duration=2)
 
     model.add_timing_precedence(operations[0], operations[1], prec_type)
 
@@ -235,7 +235,7 @@ def test_timing_precedence_with_one_delay(
 
     for machine in machines:
         for operation in operations:
-            model.add_processing_time(operation, machine, duration=2)
+            model.add_processing_time(machine, operation, duration=2)
 
     model.add_timing_precedence(
         operations[0], operations[1], prec_type, delay=1
@@ -271,7 +271,7 @@ def test_assignment_precedence(
 
     for machine in machines:
         for operation in operations:
-            model.add_processing_time(operation, machine, duration=2)
+            model.add_processing_time(machine, operation, duration=2)
 
     model.add_assignment_precedence(operations[0], operations[1], prec_type)
 

--- a/tests/examples/test_flowshop.py
+++ b/tests/examples/test_flowshop.py
@@ -27,7 +27,7 @@ def test_flowshop():
         model.assign_job_operations(job, operations)
 
         for machine, op in zip(machines, operations):
-            model.add_processing_time(op, machine, random.randint(1, 10))
+            model.add_processing_time(machine, op, random.randint(1, 10))
 
         # Create precedence constraints between operations.
         for idx in range(len(operations) - 1):

--- a/tests/examples/test_flowshop.py
+++ b/tests/examples/test_flowshop.py
@@ -27,7 +27,6 @@ def test_flowshop():
         model.assign_job_operations(job, operations)
 
         for machine, op in zip(machines, operations):
-            model.assign_machine_operations(machine, [op])
             model.add_processing_time(op, machine, random.randint(1, 10))
 
         # Create precedence constraints between operations.

--- a/tests/examples/test_jobshop.py
+++ b/tests/examples/test_jobshop.py
@@ -26,24 +26,18 @@ def test_jobshop():
     machines = [model.add_machine() for _ in range(3)]
 
     for job_idx, tasks in enumerate(jobs_data):
-        ops = []
-
-        # Create operations.
-        for machine_idx, _ in tasks:
-            op = model.add_operation()
-            model.assign_job_operations(jobs[job_idx], [op])
-            model.assign_machine_operations(machines[machine_idx], [op])
-            ops.append(op)
+        operations = [model.add_operation() for _ in tasks]
+        model.assign_job_operations(jobs[job_idx], operations)
 
         # Add processing times.
         for idx, (machine_idx, duration) in enumerate(tasks):
             model.add_processing_time(
-                ops[idx], machines[machine_idx], duration
+                operations[idx], machines[machine_idx], duration
             )
 
         # Impose linear routing precedence constraints.
-        for op_idx in range(1, len(ops)):
-            op1, op2 = ops[op_idx - 1], ops[op_idx]
+        for op_idx in range(1, len(operations)):
+            op1, op2 = operations[op_idx - 1], operations[op_idx]
             model.add_timing_precedence(
                 op1, op2, TimingPrecedence.END_BEFORE_START
             )

--- a/tests/examples/test_jobshop.py
+++ b/tests/examples/test_jobshop.py
@@ -32,7 +32,7 @@ def test_jobshop():
         # Add processing times.
         for idx, (machine_idx, duration) in enumerate(tasks):
             model.add_processing_time(
-                operations[idx], machines[machine_idx], duration
+                machines[machine_idx], operations[idx], duration
             )
 
         # Impose linear routing precedence constraints.

--- a/tests/test_Model.py
+++ b/tests/test_Model.py
@@ -20,8 +20,6 @@ def test_model_data():
     op1, op2 = operations
 
     model.assign_job_operations(job, operations)
-    model.assign_machine_operations(mach1, operations)
-    model.assign_machine_operations(mach2, operations)
 
     model.add_processing_time(op1, mach1, 1)
     model.add_processing_time(op2, mach2, 2)
@@ -47,7 +45,7 @@ def test_model_data():
     assert_equal(data.machines, machines)
     assert_equal(data.operations, operations)
     assert_equal(data.job2ops, [[0, 1]])
-    assert_equal(data.machine2ops, [[0, 1], [0, 1]])
+    assert_equal(data.machine2ops, [[0], [1]])
     assert_equal(
         data.processing_times,
         {(0, 0): 1, (1, 1): 2},

--- a/tests/test_Model.py
+++ b/tests/test_Model.py
@@ -24,7 +24,7 @@ def test_model_data():
     model.assign_machine_operations(mach2, operations)
 
     model.add_processing_time(op1, mach1, 1)
-    model.add_processing_time(operations[1], mach2, 2)
+    model.add_processing_time(op2, mach2, 2)
 
     model.add_timing_precedence(
         op1, op2, TimingPrecedence.END_BEFORE_START, 10
@@ -48,7 +48,10 @@ def test_model_data():
     assert_equal(data.operations, operations)
     assert_equal(data.job2ops, [[0, 1]])
     assert_equal(data.machine2ops, [[0, 1], [0, 1]])
-    assert_equal(data.processing_times, [[1, MAX_VALUE], [MAX_VALUE, 2]])
+    assert_equal(
+        data.processing_times,
+        {(0, 0): 1, (1, 1): 2},
+    )
     assert_equal(
         data.timing_precedences,
         {

--- a/tests/test_Model.py
+++ b/tests/test_Model.py
@@ -45,11 +45,7 @@ def test_model_data():
     assert_equal(data.machines, machines)
     assert_equal(data.operations, operations)
     assert_equal(data.job2ops, [[0, 1]])
-    assert_equal(data.machine2ops, [[0], [1]])
-    assert_equal(
-        data.processing_times,
-        {(0, 0): 1, (1, 1): 2},
-    )
+    assert_equal(data.processing_times, {(0, 0): 1, (1, 1): 2})
     assert_equal(
         data.timing_precedences,
         {

--- a/tests/test_Model.py
+++ b/tests/test_Model.py
@@ -21,8 +21,8 @@ def test_model_data():
 
     model.assign_job_operations(job, operations)
 
-    model.add_processing_time(op1, mach1, 1)
-    model.add_processing_time(op2, mach2, 2)
+    model.add_processing_time(mach1, op1, 1)
+    model.add_processing_time(mach2, op2, 2)
 
     model.add_timing_precedence(
         op1, op2, TimingPrecedence.END_BEFORE_START, 10

--- a/tests/test_ProblemData.py
+++ b/tests/test_ProblemData.py
@@ -96,15 +96,15 @@ def test_operation_attributes_raises_invalid_parameters(
         )
 
 
-def test_problem_data_attributes():
+def test_problem_data_input_parameter_attributes():
     """
-    Tests that the attributes of the ProblemData class are set correctly.
+    Tests that the input parameters of the ProblemData class are set correctly
+    as attributes.
     """
     jobs = [Job() for _ in range(5)]
     machines = [Machine() for _ in range(5)]
     operations = [Operation() for _ in range(5)]
     job2ops = [[0], [1], [2], [3], [4]]
-    machine2ops = [[0], [1], [2], [3], [4]]
     processing_times = {(i, j): 1 for i in range(5) for j in range(5)}
     timing_precedences = {
         key: [TimingPrecedence.END_BEFORE_START]
@@ -118,8 +118,7 @@ def test_problem_data_attributes():
         jobs,
         machines,
         operations,
-        job2ops,  # TODO test invalid job2ops
-        machine2ops,  # TODO test invalid machine2ops
+        job2ops,
         processing_times,
         timing_precedences,
         assignment_precedences,
@@ -131,16 +130,37 @@ def test_problem_data_attributes():
     assert_equal(data.machines, machines)
     assert_equal(data.operations, operations)
     assert_equal(data.job2ops, job2ops)
-    assert_equal(data.machine2ops, machine2ops)
     assert_equal(data.processing_times, processing_times)
     assert_equal(data.timing_precedences, timing_precedences)
     assert_equal(data.assignment_precedences, assignment_precedences)
     assert_equal(data.access_matrix, access_matrix)
     assert_allclose(data.setup_times, setup_times)
 
-    assert_equal(data.num_jobs, 5)
-    assert_equal(data.num_machines, 5)
-    assert_equal(data.num_operations, 5)
+
+def test_problem_data_non_input_parameter_attributes():
+    """
+    Tests that attributes that are not input parameters of the ProblemData
+    class are set correctly.
+    """
+    jobs = [Job() for _ in range(1)]
+    machines = [Machine() for _ in range(3)]
+    operations = [Operation() for _ in range(3)]
+    job2ops = [[0, 1, 2]]
+    processing_times = {(1, 2): 1, (2, 1): 1, (0, 1): 1, (2, 0): 1}
+
+    data = ProblemData(
+        jobs, machines, operations, job2ops, processing_times, {}
+    )
+
+    # The lists in machine2ops and op2machines are sorted.
+    machine2ops = [[1], [2], [0, 1]]
+    op2machines = [[2], [0, 2], [1]]
+    assert_equal(data.machine2ops, machine2ops)
+    assert_equal(data.op2machines, op2machines)
+
+    assert_equal(data.num_jobs, 1)
+    assert_equal(data.num_machines, 3)
+    assert_equal(data.num_operations, 3)
 
 
 def test_problem_data_default_values():
@@ -151,7 +171,6 @@ def test_problem_data_default_values():
     machines = [Machine() for _ in range(1)]
     operations = [Operation() for _ in range(1)]
     job2ops = [[0]]
-    machine2ops = [[0]]
     timing_precedences = {(0, 1): [TimingPrecedence.END_BEFORE_START]}
     processing_times = {(0, 0): 1}
     data = ProblemData(
@@ -159,7 +178,6 @@ def test_problem_data_default_values():
         machines,
         operations,
         job2ops,
-        machine2ops,
         processing_times,
         timing_precedences,
     )
@@ -196,7 +214,6 @@ def test_problem_data_raises_when_invalid_arguments(
             [Job()],
             [Machine()],
             [Operation()],
-            [[0]],
             [[0]],
             processing_times,
             {},

--- a/tests/test_ProblemData.py
+++ b/tests/test_ProblemData.py
@@ -105,7 +105,7 @@ def test_problem_data_attributes():
     operations = [Operation() for _ in range(5)]
     job2ops = [[0], [1], [2], [3], [4]]
     machine2ops = [[0], [1], [2], [3], [4]]
-    processing_times = np.ones((5, 5), dtype=int)
+    processing_times = {(i, j): 1 for i in range(5) for j in range(5)}
     timing_precedences = {
         key: [TimingPrecedence.END_BEFORE_START]
         for key in ((0, 1), (2, 3), (4, 5))
@@ -132,7 +132,7 @@ def test_problem_data_attributes():
     assert_equal(data.operations, operations)
     assert_equal(data.job2ops, job2ops)
     assert_equal(data.machine2ops, machine2ops)
-    assert_allclose(data.processing_times, processing_times)
+    assert_equal(data.processing_times, processing_times)
     assert_equal(data.timing_precedences, timing_precedences)
     assert_equal(data.assignment_precedences, assignment_precedences)
     assert_equal(data.access_matrix, access_matrix)
@@ -153,7 +153,7 @@ def test_problem_data_default_values():
     job2ops = [[0]]
     machine2ops = [[0]]
     timing_precedences = {(0, 1): [TimingPrecedence.END_BEFORE_START]}
-    processing_times = np.ones((1, 1), dtype=int)
+    processing_times = {(0, 0): 1}
     data = ProblemData(
         jobs,
         machines,
@@ -173,19 +173,17 @@ def test_problem_data_default_values():
     "processing_times, access_matrix, setup_times",
     [
         # Negative processing times.
-        (np.ones((1, 1)) * -1, np.full((1, 1), True), np.ones((1, 1, 1))),
-        # Invalid processing times shape.
-        (np.ones((2, 2)), np.full((1, 1), True), np.ones((1, 1, 1))),
+        ({(0, 0): -1}, np.full((1, 1), True), np.ones((1, 1, 1))),
         # Negative setup times.
-        (np.ones((1, 1)), np.full((1, 1), True), np.ones((1, 1, 1)) * -1),
+        ({(0, 0): 1}, np.full((1, 1), True), np.ones((1, 1, 1)) * -1),
         # Invalid setup times shape.
-        (np.ones((1, 1)), np.full((1, 1), True), np.ones((2, 2, 2))),
+        ({(0, 0): 1}, np.full((1, 1), True), np.ones((2, 2, 2))),
         # Invalid access matrix shape.
-        (np.ones((1, 1)), np.full((2, 2), True), np.ones((1, 1, 1))),
+        ({(0, 0): 1}, np.full((2, 2), True), np.ones((1, 1, 1))),
     ],
 )
 def test_problem_data_raises_when_invalid_arguments(
-    processing_times: np.ndarray,
+    processing_times: dict[tuple[int, int], int],
     access_matrix: np.ndarray,
     setup_times: np.ndarray,
 ):
@@ -200,7 +198,7 @@ def test_problem_data_raises_when_invalid_arguments(
             [Operation()],
             [[0]],
             [[0]],
-            processing_times.astype(int),
+            processing_times,
             {},
             {},
             access_matrix.astype(int),


### PR DESCRIPTION
Closes #52.

In summary:
- `ProblemData.processing_times` now expects a dictionary with `(machine, operation)` and duration key-value pairs. The matrix was unnecessary because the data is very sparse and we don't need any matrix computations anyway. (Note: this may change when we use heuristics!)
- `ProblemData.machine2ops` is removed and should be inferred from the keys in `ProblemData.processing_times` instead.