### PR TITLE
Job weight and due date

### DIFF
--- a/pyjobshop/Model.py
+++ b/pyjobshop/Model.py
@@ -101,18 +101,19 @@ class Model:
         Parameters
         ----------
         weight: int
-            The importance weight, used as contribution factor in the objective.
+            The job importance weight, used as multiplicative factor in the
+            objective function.
         release_date: int
-            The first moment when the job is available for processing. Default 0.
+            The earliest time that the job can start processing. Default is zero.
         due_date: Optional[int]
-            The latest time by which completion must happen before incurring
-            penalties. Default is None, which is no due date.
+            The latest time that the job should be completed before incurring
+            penalties. Default is None, meaning that there is no due date.
         deadline: Optional[int]
-            The last moment before which the job must be completed.
-            Note that this is different from ``due_date``, which does not restrict
-            the latest completion time. Default is None, which is no deadline.
+            The latest time that the job must be completed. Note that a deadline
+            is different from a due date; the latter does not constrain the latest
+            completion time. Default is None, meaning that there is no deadline.
         name: Optional[str]
-            Name of the job.
+            Name of the job. Default is None.
 
         Returns
         -------

--- a/pyjobshop/Model.py
+++ b/pyjobshop/Model.py
@@ -89,7 +89,9 @@ class Model:
 
     def add_job(
         self,
+        weight: int = 1,
         release_date: int = 0,
+        due_date: Optional[int] = None,
         deadline: Optional[int] = None,
         name: Optional[str] = None,
     ) -> Job:
@@ -98,19 +100,26 @@ class Model:
 
         Parameters
         ----------
+        weight: int
+            The importance weight, used as contribution factor in the objective.
         release_date: int
-            Release date of the job. Defaults to 0.
+            The first moment when the job is available for processing. Default 0.
+        due_date: Optional[int]
+            The latest time by which completion must happen before incurring
+            penalties. Default is None, which is no due date.
         deadline: Optional[int]
-            Optional deadline of the job.
+            The last moment before which the job must be completed.
+            Note that this is different from ``due_date``, which does not restrict
+            the latest completion time. Default is None, which is no deadline.
         name: Optional[str]
-            Optional name of the job.
+            Name of the job.
 
         Returns
         -------
         Job
             The created job.
         """
-        job = Job(release_date, deadline, name)
+        job = Job(weight, release_date, due_date, deadline, name)
 
         self._id2job[id(job)] = len(self.jobs)
         self._jobs.append(job)

--- a/pyjobshop/ProblemData.py
+++ b/pyjobshop/ProblemData.py
@@ -6,19 +6,51 @@ from strenum import StrEnum
 
 
 class Job:
+    """
+    Simple dataclass storing all job-related data.
+
+    Parameters
+    ----------
+    weight: int
+        The importance weight, used as contribution factor in the objective.
+    release_date: int
+        The first moment when the job is available for processing. Default 0.
+    due_date: Optional[int]
+        The latest time by which completion must happen before incurring
+        penalties. Default is None, which is no due date.
+    deadline: Optional[int]
+        The last moment before which the job must be completed.
+        Note that this is different from ``due_date``, which does not restrict
+        the latest completion time. Default is None, which is no deadline.
+    name: Optional[str]
+        Name of the job.
+    """
+
     def __init__(
         self,
+        weight: int = 1,
         release_date: int = 0,
+        due_date: Optional[int] = None,
         deadline: Optional[int] = None,
         name: Optional[str] = None,
     ):
+        self._weight = weight
         self._release_date = release_date
+        self._due_date = due_date
         self._deadline = deadline
         self._name = name
 
     @property
+    def weight(self) -> int:
+        return self._weight
+
+    @property
     def release_date(self) -> int:
         return self._release_date
+
+    @property
+    def due_date(self) -> Optional[int]:
+        return self._due_date
 
     @property
     def deadline(self) -> Optional[int]:
@@ -31,7 +63,7 @@ class Job:
 
 class Machine:
     """
-    A machine represents a resource that can process operations.
+    Simple dataclass for storing all machine-related data.
 
     Parameters
     ----------
@@ -49,7 +81,7 @@ class Machine:
 
 class Operation:
     """
-    An operation is a task that must be processed by a machine.
+    Simple dataclass storing all operation-related data.
 
     Parameters
     ----------

--- a/pyjobshop/ProblemData.py
+++ b/pyjobshop/ProblemData.py
@@ -34,6 +34,21 @@ class Job:
         deadline: Optional[int] = None,
         name: Optional[str] = None,
     ):
+        if weight < 0:
+            raise ValueError("Weight must be non-negative.")
+
+        if release_date < 0:
+            raise ValueError("Release date must be non-negative.")
+
+        if due_date is not None and due_date < 0:
+            raise ValueError("Due date must be non-negative.")
+
+        if deadline is not None and deadline < 0:
+            raise ValueError("Deadline must be non-negative.")
+
+        if deadline is not None and release_date > deadline:
+            raise ValueError("Must have release_date <= deadline.")
+
         self._weight = weight
         self._release_date = release_date
         self._due_date = due_date

--- a/pyjobshop/ProblemData.py
+++ b/pyjobshop/ProblemData.py
@@ -7,23 +7,24 @@ from strenum import StrEnum
 
 class Job:
     """
-    Simple dataclass storing all job-related data.
+    Simple dataclass for storing all job-related data.
 
     Parameters
     ----------
     weight: int
-        The importance weight, used as contribution factor in the objective.
+        The job importance weight, used as multiplicative factor in the
+        objective function.
     release_date: int
-        The first moment when the job is available for processing. Default 0.
+        The earliest time that the job can start processing. Default is zero.
     due_date: Optional[int]
-        The latest time by which completion must happen before incurring
-        penalties. Default is None, which is no due date.
+        The latest time that the job should be completed before incurring
+        penalties. Default is None, meaning that there is no due date.
     deadline: Optional[int]
-        The last moment before which the job must be completed.
-        Note that this is different from ``due_date``, which does not restrict
-        the latest completion time. Default is None, which is no deadline.
+        The latest time that the job must be completed. Note that a deadline
+        is different from a due date; the latter does not constrain the latest
+        completion time. Default is None, meaning that there is no deadline.
     name: Optional[str]
-        Name of the job.
+        Name of the job. Default is None.
     """
 
     def __init__(
@@ -96,7 +97,7 @@ class Machine:
 
 class Operation:
     """
-    Simple dataclass storing all operation-related data.
+    Simple dataclass for storing all operation-related data.
 
     Parameters
     ----------

--- a/pyjobshop/cp/constraints.py
+++ b/pyjobshop/cp/constraints.py
@@ -12,6 +12,23 @@ AssignVars = dict[tuple[int, int], CpoIntervalVar]
 SeqVars = list[CpoSequenceVar]
 
 
+def job_data_constraints(
+    m: CpoModel, data: ProblemData, job_vars: JobVars
+) -> list[CpoExpr]:
+    """
+    Creates constraints related to the job data.
+    """
+    constraints = []
+
+    for job_data, job_var in zip(data.jobs, job_vars):
+        constraints.append(m.start_of(job_var) >= job_data.release_date)
+
+        if job_data.deadline is not None:
+            constraints.append(m.end_of(job_var) <= job_data.deadline)
+
+    return constraints
+
+
 def job_operation_constraints(
     m: CpoModel, data: ProblemData, job_vars: JobVars, op_vars: OpVars
 ) -> list[CpoExpr]:

--- a/pyjobshop/cp/default_model.py
+++ b/pyjobshop/cp/default_model.py
@@ -5,6 +5,7 @@ from pyjobshop.ProblemData import ProblemData
 from .constraints import (
     alternative_constraints,
     assignment_precedence_constraints,
+    job_data_constraints,
     job_operation_constraints,
     machine_accessibility_constraints,
     no_overlap_constraints,
@@ -34,6 +35,7 @@ def default_model(data: ProblemData) -> CpoModel:
 
     model.add(makespan(model, data, job_vars))
 
+    model.add(job_data_constraints(model, data, job_vars))
     model.add(job_operation_constraints(model, data, job_vars, op_vars))
     model.add(operation_constraints(model, data, op_vars))
     model.add(timing_precedence_constraints(model, data, op_vars))

--- a/tests/test_Model.py
+++ b/tests/test_Model.py
@@ -77,10 +77,14 @@ def test_add_job_attributes():
     """
     model = Model()
 
-    job = model.add_job(deadline=1, release_date=2, name="job")
+    job = model.add_job(
+        weight=0, release_date=1, due_date=2, deadline=3, name="job"
+    )
 
-    assert_equal(job.deadline, 1)
-    assert_equal(job.release_date, 2)
+    assert_equal(job.weight, 0)
+    assert_equal(job.release_date, 1)
+    assert_equal(job.due_date, 2)
+    assert_equal(job.deadline, 3)
     assert_equal(job.name, "job")
 
 

--- a/tests/test_ProblemData.py
+++ b/tests/test_ProblemData.py
@@ -21,15 +21,19 @@ def test_job_attributes():
     # Let's first test the default values.
     job = Job()
 
+    assert_equal(job.weight, 1)
     assert_equal(job.release_date, 0)
+    assert_equal(job.due_date, None)
     assert_equal(job.deadline, None)
     assert_equal(job.name, None)
 
     # Now test with some values.
-    job = Job(5, 10, "test")
+    job = Job(weight=0, release_date=1, due_date=2, deadline=3, name="test")
 
-    assert_equal(job.release_date, 5)
-    assert_equal(job.deadline, 10)
+    assert_equal(job.weight, 0)
+    assert_equal(job.release_date, 1)
+    assert_equal(job.due_date, 2)
+    assert_equal(job.deadline, 3)
     assert_equal(job.name, "test")
 
 

--- a/tests/test_ProblemData.py
+++ b/tests/test_ProblemData.py
@@ -27,6 +27,19 @@ def test_job_attributes():
     assert_equal(job.name, "test")
 
 
+def test_job_default_attributes():
+    """
+    Tests that the default attributes of the Job class are set correctly.
+    """
+    job = Job(weight=0, release_date=1, due_date=2, deadline=3, name="test")
+
+    assert_equal(job.weight, 0)
+    assert_equal(job.release_date, 1)
+    assert_equal(job.due_date, 2)
+    assert_equal(job.deadline, 3)
+    assert_equal(job.name, "test")
+
+
 @pytest.mark.parametrize(
     "weight, release_date, due_date, deadline, name",
     [
@@ -37,7 +50,7 @@ def test_job_attributes():
         (0, 10, 0, 0, ""),  # release_date > deadline
     ],
 )
-def test_job_default_attributes(
+def test_job_attributes_raises_invalid_parameters(
     weight: int, release_date: int, due_date: int, deadline: int, name: str
 ):
     """
@@ -51,13 +64,6 @@ def test_job_default_attributes(
             deadline=deadline,
             name=name,
         )
-
-
-def test_job_attributes_raises_invalid_parameters():
-    """
-    x
-    """
-    pass
 
 
 def test_machine_attributes():

--- a/tests/test_ProblemData.py
+++ b/tests/test_ProblemData.py
@@ -31,13 +31,13 @@ def test_job_default_attributes():
     """
     Tests that the default attributes of the Job class are set correctly.
     """
-    job = Job(weight=0, release_date=1, due_date=2, deadline=3, name="test")
+    job = Job()
 
-    assert_equal(job.weight, 0)
-    assert_equal(job.release_date, 1)
-    assert_equal(job.due_date, 2)
-    assert_equal(job.deadline, 3)
-    assert_equal(job.name, "test")
+    assert_equal(job.weight, 1)
+    assert_equal(job.release_date, 0)
+    assert_equal(job.due_date, None)
+    assert_equal(job.deadline, None)
+    assert_equal(job.name, None)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_ProblemData.py
+++ b/tests/test_ProblemData.py
@@ -18,16 +18,6 @@ def test_job_attributes():
     """
     Tests that the attributes of the Job class are set correctly.
     """
-    # Let's first test the default values.
-    job = Job()
-
-    assert_equal(job.weight, 1)
-    assert_equal(job.release_date, 0)
-    assert_equal(job.due_date, None)
-    assert_equal(job.deadline, None)
-    assert_equal(job.name, None)
-
-    # Now test with some values.
     job = Job(weight=0, release_date=1, due_date=2, deadline=3, name="test")
 
     assert_equal(job.weight, 0)
@@ -35,6 +25,39 @@ def test_job_attributes():
     assert_equal(job.due_date, 2)
     assert_equal(job.deadline, 3)
     assert_equal(job.name, "test")
+
+
+@pytest.mark.parametrize(
+    "weight, release_date, due_date, deadline, name",
+    [
+        (-1, 0, 0, 0, ""),  # weight < 0
+        (0, -1, 0, 0, ""),  # release_date < 0
+        (0, 0, -1, 0, ""),  # due_date < 0
+        (0, 0, 0, -1, ""),  # deadline < 0
+        (0, 10, 0, 0, ""),  # release_date > deadline
+    ],
+)
+def test_job_default_attributes(
+    weight: int, release_date: int, due_date: int, deadline: int, name: str
+):
+    """
+    Tests that the default values for each job attribute is set correctly.
+    """
+    with assert_raises(ValueError):
+        Job(
+            weight=weight,
+            release_date=release_date,
+            due_date=due_date,
+            deadline=deadline,
+            name=name,
+        )
+
+
+def test_job_attributes_raises_invalid_parameters():
+    """
+    x
+    """
+    pass
 
 
 def test_machine_attributes():


### PR DESCRIPTION
This PR:
- Is part of #43.
- Adds the weight and due date attribute to `Job`.
- Redefines behavior of the current `job.deadline` attribute, which was interpreted as due date.
