### PR TITLE
Allow overlap on machines

### DIFF
--- a/pyjobshop/Model.py
+++ b/pyjobshop/Model.py
@@ -137,6 +137,7 @@ class Model:
         self,
         available_from: Optional[int] = None,
         available_till: Optional[int] = None,
+        allow_overlap: bool = False,
         name: Optional[str] = None,
     ) -> Machine:
         """
@@ -150,6 +151,9 @@ class Model:
         available_till: Optional[int]
             Latest time that the machine is available for processing.
             Default is None, meaning there is no restriction.
+        allow_overlap: False
+            Whether it is allowed to schedule multiple operations on the
+            machine at the same time. Default is False.
         name: Optional[str]
             Optional name of the machine.
 
@@ -158,7 +162,12 @@ class Model:
         Machine
             The created machine.
         """
-        machine = Machine(available_from, available_till, name=name)
+        machine = Machine(
+            available_from=available_from,
+            available_till=available_till,
+            allow_overlap=allow_overlap,
+            name=name,
+        )
 
         self._id2machine[id(machine)] = len(self.machines)
         self._machines.append(machine)

--- a/pyjobshop/ProblemData.py
+++ b/pyjobshop/ProblemData.py
@@ -89,6 +89,9 @@ class Machine:
     available_till: Optional[int]
         Latest time that the machine is available for processing.
         Default is None, meaning there is no restriction.
+    allow_overlap: bool
+        Whether it is allowed to schedule multiple operations on the machine
+        at the same time. Default is False.
     name: Optional[str]
         Optional name of the machine.
     """
@@ -97,6 +100,7 @@ class Machine:
         self,
         available_from: Optional[int] = None,
         available_till: Optional[int] = None,
+        allow_overlap: bool = False,
         name: Optional[str] = None,
     ):
         if available_from is not None and available_till is not None:
@@ -105,6 +109,7 @@ class Machine:
 
         self._available_from = available_from
         self._available_till = available_till
+        self._allow_overlap = allow_overlap
         self._name = name
 
     @property
@@ -114,6 +119,10 @@ class Machine:
     @property
     def available_till(self) -> Optional[int]:
         return self._available_till
+
+    @property
+    def allow_overlap(self) -> bool:
+        return self._allow_overlap
 
     @property
     def name(self) -> Optional[str]:

--- a/pyjobshop/cp/constraints.py
+++ b/pyjobshop/cp/constraints.py
@@ -171,6 +171,9 @@ def no_overlap_and_setup_time_constraints(
     # Assumption: the interval variables in the sequence variable
     # are ordered in the same way as the operations in machine2ops.
     for machine in range(data.num_machines):
+        if data.machines[machine].allow_overlap:
+            continue  # Overlap is allowed for this machine.
+
         if not (ops := data.machine2ops[machine]):
             continue  # There no operations for this machine.
 

--- a/pyjobshop/cp/constraints.py
+++ b/pyjobshop/cp/constraints.py
@@ -159,7 +159,7 @@ def machine_data_constraints(
     return constraints
 
 
-def no_overlap_constraints(
+def no_overlap_and_setup_time_constraints(
     m: CpoModel, data: ProblemData, seq_vars: SeqVars
 ) -> list[CpoExpr]:
     """

--- a/pyjobshop/cp/default_model.py
+++ b/pyjobshop/cp/default_model.py
@@ -9,7 +9,7 @@ from .constraints import (
     job_operation_constraints,
     machine_accessibility_constraints,
     machine_data_constraints,
-    no_overlap_constraints,
+    no_overlap_and_setup_time_constraints,
     operation_constraints,
     optional_operation_selection_constraints,
     timing_precedence_constraints,
@@ -52,7 +52,7 @@ def default_model(data: ProblemData) -> CpoModel:
         assignment_precedence_constraints(model, data, assign_vars, seq_vars)
     )
     model.add(alternative_constraints(model, data, op_vars, assign_vars))
-    model.add(no_overlap_constraints(model, data, seq_vars))
+    model.add(no_overlap_and_setup_time_constraints(model, data, seq_vars))
     model.add(machine_accessibility_constraints(model, data, assign_vars))
     model.add(optional_operation_selection_constraints(model, data, op_vars))
 

--- a/tests/test_Model.py
+++ b/tests/test_Model.py
@@ -100,10 +100,13 @@ def test_add_machine_attributes():
     """
     model = Model()
 
-    machine = model.add_machine(1, 2, name="machine")
+    machine = model.add_machine(
+        available_from=1, available_till=2, allow_overlap=True, name="machine"
+    )
 
     assert_equal(machine.available_from, 1)
     assert_equal(machine.available_till, 2)
+    assert_equal(machine.allow_overlap, True)
     assert_equal(machine.name, "machine")
 
 


### PR DESCRIPTION
This PR adds the `allow_overlap` attribute on machines. Setting this parameter to true allows operations to overlap on machines, which will be eventually useful for batching and storage resources. 