### PR TITLE
Make CPLEX optional

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
       - name: Install Python dependencies
         if: steps.cache-python.outputs.cache-hit != 'true'
-        run: poetry install
+        run: poetry install --all-extras
       - name: Cache pre-commit
         uses: actions/cache@v3
         id: cache-pre-commit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,14 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.dependencies]
 python = ">=3.9, <3.11"
-cplex = "22.1.1.0"
 docplex = "^2.25.236"
 numpy = "^1.24.2"
 matplotlib = "^3.7.1"
+cplex = { version = "22.1.1.0", optional = true }
+
+
+[tool.poetry.extras]
+cplex = ["cplex"]
 
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,14 +17,14 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.dependencies]
 python = ">=3.9, <3.11"
-docplex = "^2.25.236"
 numpy = "^1.24.2"
 matplotlib = "^3.7.1"
+docplex = { version = "^2.25.236", optional = true }
 cplex = { version = "22.1.1.0", optional = true }
 
 
 [tool.poetry.extras]
-cplex = ["cplex"]
+cplex = ["cplex", "docplex"]
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
This PR makes the `cplex` package dependency optional.  

After #26, OR-Tools will become the default. But I'm having some CPLEX dependency issues already (see #49) which makes development a bit difficult. This PR (hopefully) fixes that.