### PR TITLE
Remove type hints in docstrings

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -2,7 +2,7 @@ Welcome to PyJobShop's documentation!
 =====================================
 
 **PyJobShop** is a Python library for modeling and solving scheduling problems.
-It provides an *easy-to-use* modeling interface and uses *state-of-the-art* constraint programming solvers to find the optimal schedule.
+This library provides an easy-to-use modeling interface and uses constraint programming solvers to find the optimal solution.
 
 .. note::
 

--- a/pyjobshop/Model.py
+++ b/pyjobshop/Model.py
@@ -101,20 +101,20 @@ class Model:
 
         Parameters
         ----------
-        weight: int
+        weight
             The job importance weight, used as multiplicative factor in the
             objective function.
-        release_date: int
+        release_date
             The earliest time that the job may start. Default is zero.
-        due_date: Optional[int]
+        due_date
             The latest time that the job should be completed before incurring
             penalties. Default is None, meaning that there is no due date.
-        deadline: Optional[int]
+        deadline
             The latest time by which the job must be completed. Note that a
             deadline is different from a due date; the latter does not restrict
             the latest completion time. Default is None, meaning that there is
             no deadline.
-        name: str
+        name
             Name of the job.
 
         Returns
@@ -140,14 +140,14 @@ class Model:
 
         Parameters
         ----------
-        downtimes: Iterable[tuple[int, int]]
+        downtimes
             List of downtimes for the machine. A downtime is a time interval
             [start, end) during which the machine is unavailable for
             processing. Defaults to no downtimes.
-        allow_overlap: False
+        allow_overlap
             Whether it is allowed to schedule multiple operations on the
-            machine at the same time. Default is False.
-        name: str
+            machine at the same time. Default ``False``.
+        name
             Name of the machine.
 
         Returns
@@ -182,21 +182,21 @@ class Model:
 
         Parameters
         ----------
-        job: Optional[Job]
+        job
             The job that the operation belongs to.
-        earliest_start: Optional[int]
+        earliest_start
             Earliest start time of the operation.
-        latest_start: Optional[int]
+        latest_start
             Latest start time of the operation.
-        earliest_end: Optional[int]
+        earliest_end
             Earliest end time of the operation.
-        latest_end: Optional[int]
+        latest_end
             Latest end time of the operation.
-        fixed_duration: bool
+        fixed_duration
             Whether the duration of the operation is fixed. Defaults to True.
-        optional: bool
+        optional
             Whether processing this operation is optional. Defaults to False.
-        name: str
+        name
             Name of the operation.
 
         Returns
@@ -232,11 +232,11 @@ class Model:
 
         Parameters
         ----------
-        machine: Machine
+        machine
             The machine on which the operation is processed.
-        operation: Operation
+        operation
             An operation.
-        duration: int
+        duration
             Processing time of the operation on the machine.
         """
         if duration < 0:
@@ -258,15 +258,15 @@ class Model:
 
         Parameters
         ----------
-        operation1: Operation
+        operation1
             First operation.
-        operation2: Operation
+        operation2
             Second operation.
-        constraint: TimingPrecedence
+        constraint
             Timing precedence constraint between the first and the second
-            operation. Defaults to END_BEFORE_START, meaning that the first
+            operation. Defaults to ``END_BEFORE_START``, meaning that the first
             operation must end before the second operation starts.
-        delay: int
+        delay
             Delay between the first and the second operation. Defaults to
             zero (no delay).
         """
@@ -285,11 +285,11 @@ class Model:
 
         Parameters
         ----------
-        operation1: Operation
+        operation1
             First operation.
-        operation2: Operation
+        operation2
             Second operation.
-        assignment_precedence: AssignmentPrecedence
+        assignment_precedence
             Assignment precedence relation between the first and the second
             operation.
 
@@ -310,13 +310,13 @@ class Model:
 
         Parameters
         ----------
-        machine: Machine
+        machine
             Machine on which the setup time occurs.
-        operation1: Operation
+        operation1
             First operation.
-        operation2: Operation
+        operation2
             Second operation.
-        duration: int
+        duration
             Duration of the setup time when switching from the first operation
             to the second operation on the machine.
         """
@@ -334,7 +334,7 @@ class Model:
 
         Parameters
         ----------
-        plans: list[Operation]
+        plans
             The plans to be added. Each plan is a list of operations. Multiple
             plans can be passed as separate arguments.
         """
@@ -347,7 +347,7 @@ class Model:
 
         Parameters
         ----------
-        horizon: int
+        horizon
             The planning horizon.
         """
         self._planning_horizon = horizon
@@ -358,7 +358,7 @@ class Model:
 
         Parameters
         ----------
-        objective: Objective
+        objective
             An objective function.
         """
         self._objective = objective
@@ -371,9 +371,9 @@ class Model:
 
         Parameters
         ----------
-        log: bool
+        log
             Whether to log the solver output. Defaults to False.
-        time_limit: Optional[int]
+        time_limit
             Time limit in seconds for the solver, defaults to None. If set to
             None, the solver will run until an optimal solution is found.
 

--- a/pyjobshop/ProblemData.py
+++ b/pyjobshop/ProblemData.py
@@ -11,19 +11,19 @@ class Job:
 
     Parameters
     ----------
-    weight: int
+    weight
         The job importance weight, used as multiplicative factor in the
         objective function.
-    release_date: int
+    release_date
         The earliest time that the job can start processing. Default is zero.
-    due_date: Optional[int]
+    due_date
         The latest time that the job should be completed before incurring
         penalties. Default is None, meaning that there is no due date.
-    deadline: Optional[int]
+    deadline
         The latest time that the job must be completed. Note that a deadline
         is different from a due date; the latter does not constrain the latest
         completion time. Default is None, meaning that there is no deadline.
-    name: str
+    name
         Name of the job.
     """
 
@@ -83,14 +83,14 @@ class Machine:
 
     Parameters
     ----------
-    downtimes: Iterable[tuple[int, int]]
+    downtimes
         List of downtimes for the machine. A downtime is a time interval
         [start, end) during which the machine is unavailable for processing.
         Defaults to no downtimes.
-    allow_overlap: bool
+    allow_overlap
         Whether it is allowed to schedule multiple operations on the machine
         at the same time. Default is False.
-    name: str
+    name
         Name of the machine.
     """
 
@@ -127,23 +127,23 @@ class Operation:
 
     Parameters
     ----------
-    earliest_start: Optional[int]
+    earliest_start
         Earliest start time of the operation.
-    latest_start: Optional[int]
+    latest_start
         Latest start time of the operation.
-    earliest_end: Optional[int]
+    earliest_end
         Earliest end time of the operation.
-    latest_end: Optional[int]
+    latest_end
         Latest end time of the operation.
-    fixed_duration: bool
+    fixed_duration
         Whether the operation has a fixed duration. A fixed duration means that
         the operation duration is precisely the processing time (on a given
         machine). If the duration is not fixed, then the operation duration
         can take longer than the processing time, e.g., due to blocking.
         Default is True.
-    optional: bool
+    optional
         Whether processing this operation is optional. Defaults to False.
-    name: str
+    name
         Name of the operation.
     """
 
@@ -278,15 +278,15 @@ class ProblemData:
 
     Parameters
     ----------
-    jobs: list[Job]
+    jobs
         List of jobs.
-    machines: list[Machine]
+    machines
         List of machines.
-    operations: list[Operation]
+    operations
         List of operations.
-    job2ops: list[list[int]]
+    job2ops
         List of operation indices for each job.
-    processing_times: dict[tuple[int, int], int]
+    processing_times
         Processing times of operations on machines. First index is the machine
         index, second index is the operation index.
     timing_precedences
@@ -295,19 +295,19 @@ class ProblemData:
     assignment_precedences
         Dict indexed by operation pairs with list of assignment precedence
         constraints.
-    setup_times: Optional[np.ndarray]
+    setup_times
         Sequence-dependent setup times between operations on a given machine.
         The first dimension of the array is indexed by the machine index. The
         last two dimensions of the array are indexed by operation indices.
-    process_plans: Optional[list[list[list[int]]]]
+    process_plans
         List of processing plans. Each process plan represents a list
         containing lists of operation indices, one of which is selected to be
         scheduled. All operations from the selected list are then scheduled,
         while operations from unselected lists will not be scheduled.
-    planning_horizon: Optional[int]
+    planning_horizon
         The planning horizon value. Default is None, meaning that the planning
         horizon is unbounded.
-    objective: Objective
+    objective
         The objective function to be minimized. Default is the makespan.
     """
 

--- a/pyjobshop/Result.py
+++ b/pyjobshop/Result.py
@@ -9,11 +9,11 @@ class Result:
 
     Parameters
     ----------
-    solve_status: str
+    solve_status
         The solve status.
-    solution: Optional[Solution]
+    solution
         The solution to the problem instance. None if no solution was found.
-    objective_value: Optional[float]
+    objective_value
         The objective value of the solution. None if no solution was found.
     """
 

--- a/pyjobshop/Solution.py
+++ b/pyjobshop/Solution.py
@@ -7,13 +7,13 @@ class Task:
 
     Parameters
     ----------
-    operation: int
+    operation
         The operation index.
-    machine: int
+    machine
         The machine to which the operation is assigned.
-    start: int
+    start
         The start time of the operation.
-    duration: int
+    duration
         The duration of the operation.
     """
 
@@ -56,9 +56,9 @@ class Solution:
 
     Parameters
     ----------
-    data: ProblemData
-        The problem data.
-    schedule: list[Task]
+    data
+        The problem data instance.
+    schedule
         A list of tasks.
     """
 

--- a/pyjobshop/cp/default_model.py
+++ b/pyjobshop/cp/default_model.py
@@ -32,6 +32,16 @@ from .variables import (
 def default_model(data: ProblemData) -> CpoModel:
     """
     Creates a CP model for the given problem data.
+
+    Parameters
+    ----------
+    data
+        The problem data instance.
+
+    Returns
+    -------
+    CpoModel
+        The CP model for the given problem data.
     """
     model = CpoModel()
 

--- a/pyjobshop/plot.py
+++ b/pyjobshop/plot.py
@@ -20,16 +20,16 @@ def plot(
 
     Parameters
     ----------
-    data: ProblemData
+    data
         The problem data instance.
-    solution: Solution
+    solution
         A solution to the problem.
-    machine_order: Optional[list[int]]
+    machine_order
         The machines (by index) to plot and in which order they should appear
         (from top to bottom). Defaults to all machines in the data instance.
-    plot_labels: bool
+    plot_labels
         Whether to plot the operation names as labels.
-    ax: plt.Axes
+    ax
         Axes object to draw the plot on. One will be created if not provided.
     """
     if ax is None:


### PR DESCRIPTION
This PR removes type hints from parameter descriptions in docstrings. The reason is that the documentation infers the types from the signature; adding these again in the docstrings results in faulty renders. Part of #63.